### PR TITLE
default.nix: track default Nixpkgs GHC by default

### DIFF
--- a/.github/workflows/Nixpkgs-Linux-additional.yml
+++ b/.github/workflows/Nixpkgs-Linux-additional.yml
@@ -32,7 +32,7 @@ env:
 jobs:
 
   build40:
-    name: "Nixpkgs-unstable channel, default GHC (8.8.3)"
+    name: "Nixpkgs-unstable channel, default GHC (8.8)"
     runs-on: ubuntu-latest
     continue-on-error: true
     env:

--- a/.github/workflows/Nixpkgs-Linux-main.yml
+++ b/.github/workflows/Nixpkgs-Linux-main.yml
@@ -61,7 +61,7 @@ jobs:
 
   # NOTE: Basic example
   build10:
-    name: "NixOS-unstable channel, default GHC (8.8.3)"
+    name: "NixOS-unstable channel, default GHC (8.8)"
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
@@ -118,7 +118,7 @@ jobs:
 
   # NOTE: Build on latest stable NixOS release
   build30:
-    name: "NixOS 20.03 stable channel, default GHC (8.8.3)"
+    name: "NixOS 20.03 stable channel, default GHC (8.8)"
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,8 @@ jobs:
         - linkWithGold='true'
       os: linux
       dist: bionic
-    - name: GHC 8.8.3, macOS, Strict
+    - name: default GHC, macOS, Strict
       env:
-        - compiler='ghc883'
         - buildStrictly='true'
       os: osx
     - name: GHC 8.10.1, Linux, SDist, Optimize, Benchmark, Haddock, Shell Completions

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,17 +72,17 @@ env:
 # {os} x {jobs} + {jobs:include} - {jobs:exclude} = {build matrix}
 jobs:
   include:
-    - name: GHC 8.6.5, Linux
+    - name: Nixpkgs, GHC 8.6.5, Linux
       env:
         - compiler='ghc865'
         - linkWithGold='true'
       os: linux
       dist: bionic
-    - name: default GHC (8.8), macOS, Strict
+    - name: Nixpkgs, default GHC (8.8), macOS, Strict
       env:
         - buildStrictly='true'
       os: osx
-    - name: GHC 8.10.1, Linux, SDist, Optimize, Benchmark, Haddock, Shell Completions
+    - name: Nipkgs, GHC 8.10.1, Linux, SDist, Optimize, Benchmark, Haddock, Shell Completions
       env:
         - compiler='ghc8101'
         - buildFromSdist='true'
@@ -95,7 +95,7 @@ jobs:
         - generateOptparseApplicativeCompletions='false' #  2020-08-10: FIXME: Turn on when binary provided
       os: linux
       dist: bionic
-    - name: GHCJS, Linux
+    - name: Nixpkgs, GHCJS, Linux
       env:
         - compiler='ghcjs'
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
         - linkWithGold='true'
       os: linux
       dist: bionic
-    - name: default GHC, macOS, Strict
+    - name: default GHC (8.8), macOS, Strict
       env:
         - buildStrictly='true'
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ env:
     - doCoverage='false'
     - doBenchmark='false'
     - generateOptparseApplicativeCompletions='false'
-    - executableNamesToShellComplete='[ "hnix" ]'
+    - executableNamesToShellComplete='[ "replaceWithExecutableFileName" ]'
     #
     - withHoogle='false'
     #

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ jobs:
         - doBenchmark='true'
         - disableOptimization='false'
         - enableDeadCodeElimination='true'
-        - generateOptparseApplicativeCompletions='true'
+        - generateOptparseApplicativeCompletions='false' #  2020-08-10: FIXME: Turn on when binary provided
       os: linux
       dist: bionic
     - name: GHCJS, Linux

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,8 @@ set -Eexuo pipefail
 
 
 # NOTE: If vars not imported - init the vars with default values
-compiler=${compiler:-'ghc883'}
+# Non-set/passed ''/'default' compiler setting means currently default GHC of Nixpkgs ecosystem.
+compiler=${compiler:-'default'}
 
 packageRoot=${packageRoot:-'pkgs.nix-gitignore.gitignoreSource [ ] ./.'}
 cabalName=${cabalName:-'replace'}
@@ -152,6 +153,7 @@ if [ "$compiler" = "ghcjs" ]
 
     # Normal GHC build
     # GHC sometimes produces logs so big - that Travis terminates builds, so multiple --quiet
+    # If $compiler provided - use the setting - otherwise - default.
     nix-build \
       --quiet --quiet \
       --argstr compiler "$compiler" \

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 {
-# Compiler in a form ghc8101 == GHC 8.10.1, just remove spaces and dots
-#  2020-07-05: Default GHC for Nixpkgs by default, for current default and explicitly supported GHC versions https://search.nixos.org/packages?query=ghc&from=0&size=500&channel=unstable, Nixpkgs implicitly supports older minor versions also, until the configuration departs from compatibility with them.
+# Default GHC for Nixpkgs by default, for current default and explicitly supported GHC versions https://search.nixos.org/packages?query=ghc&from=0&size=500&channel=unstable, Nixpkgs implicitly supports older minor versions also, until the configuration departs from compatibility with them.
+# Compiler in a form ghc8101 <- GHC 8.10.1, just remove spaces and dots
   compiler    ? "ghc${
     (
       # Remove '.' from the string 8.8.4 -> 884

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,7 @@
 {
-# Default GHC for Nixpkgs by default, for current default and explicitly supported GHC versions https://search.nixos.org/packages?query=ghc&from=0&size=500&channel=unstable, Nixpkgs implicitly supports older minor versions also, until the configuration departs from compatibility with them.
+# Default GHC for Nixpkgs by default, for current default and explicitly supported GHCs https://search.nixos.org/packages?query=ghc&from=0&size=500&channel=unstable, Nixpkgs implicitly supports older minor versions also, until the configuration departs from compatibility with them.
 # Compiler in a form ghc8101 <- GHC 8.10.1, just remove spaces and dots
-  compiler    ? "ghc${
-    (
-      # Remove '.' from the string 8.8.4 -> 884
-      pkgs.lib.stringAsChars (c: if c == "." then "" else c)
-        # Get default GHC version,
-        (pkgs.lib.getVersion pkgs.haskellPackages.ghc)
-    )
-  }"
+  compiler    ? "default"
 
 # Deafult.nix is a unit package abstraciton that allows to abstract over packages even in monorepos:
 # Example: pass --arg cabalName --arg packageRoot "./subprojectDir", or map default.nix over a list of tiples for subprojects.
@@ -119,6 +112,20 @@
 
 let
 
+ getDefaultGHC = "ghc${
+    (
+      # Remove '.' from the string 8.8.4 -> 884
+      pkgs.lib.stringAsChars (c: if c == "." then "" else c)
+        # Get default GHC version,
+        (pkgs.lib.getVersion pkgs.haskellPackages.ghc)
+    )
+  }";
+
+ compilerPackage =
+   if ((compiler == "") || (compiler == "default"))
+     then getDefaultGHC
+     else compiler;
+
   # side-overlay = pkgs.fetchFromGitHub {
   #   owner = "replaceWithAccount";
   #   repo = "replaceWithRepo";
@@ -143,7 +150,7 @@ let
       else overlay;
   };
 
-  haskellPackages = pkgs.haskell.packages.${compiler}.override
+  haskellPackages = pkgs.haskell.packages.${compilerPackage}.override
     overrideHaskellPackages;
 
   # Application of functions from this list to the package in code here happens in the reverse order (from the tail). Some options depend on & override others, so if enabling options caused Nix error or not expected result - change the order, and please do not change this order without proper testing.

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,14 @@
 {
 # Compiler in a form ghc8101 == GHC 8.10.1, just remove spaces and dots
 #  2020-07-05: Default GHC for Nixpkgs by default, for current default and explicitly supported GHC versions https://search.nixos.org/packages?query=ghc&from=0&size=500&channel=unstable, Nixpkgs implicitly supports older minor versions also, until the configuration departs from compatibility with them.
-  compiler    ? "ghc${(pkgs.lib.stringAsChars (c: if c == "." then "" else c) (pkgs.lib.getVersion pkgs.haskellPackages.ghc))}"
+  compiler    ? "ghc${
+    (
+      # Remove '.' from the string 8.8.4 -> 884
+      pkgs.lib.stringAsChars (c: if c == "." then "" else c)
+        # Get default GHC version,
+        (pkgs.lib.getVersion pkgs.haskellPackages.ghc)
+    )
+  }"
 
 # Deafult.nix is a unit package abstraciton that allows to abstract over packages even in monorepos:
 # Example: pass --arg cabalName --arg packageRoot "./subprojectDir", or map default.nix over a list of tiples for subprojects.

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 {
 # Compiler in a form ghc8101 == GHC 8.10.1, just remove spaces and dots
 #  2020-07-05: Default GHC for Nixpkgs by default, for current default and explicitly supported GHC versions https://search.nixos.org/packages?query=ghc&from=0&size=500&channel=unstable, Nixpkgs implicitly supports older minor versions also, until the configuration departs from compatibility with them.
-  compiler    ? "ghc884"
+  compiler    ? "ghc${(pkgs.lib.stringAsChars (c: if c == "." then "" else c) (pkgs.lib.getVersion pkgs.haskellPackages.ghc))}"
 
 # Deafult.nix is a unit package abstraciton that allows to abstract over packages even in monorepos:
 # Example: pass --arg cabalName --arg packageRoot "./subprojectDir", or map default.nix over a list of tiples for subprojects.


### PR DESCRIPTION
Very simple effective improvement.

Default is the default, not some random hardcode version.

Now maintainers can be free from edits to track upstream version.