### PR TITLE
Move silent GHCJS build into separate file

### DIFF
--- a/.github/workflows/Nixpkgs-GHCJS.yml
+++ b/.github/workflows/Nixpkgs-GHCJS.yml
@@ -13,12 +13,7 @@ env:
   useRev: "true"
   rev: "nixos-unstable"
   cachixAccount: "haskell-with-nixpkgs"
-  # GitHub secret
-  CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
   linkWithGold: "true"
-  compiler: "ghcjs"
-  ghcjsTmpLogFile: "/tmp/ghcjsTmpLogFile.log"
-  ghcjsLogTailLength: "10000"
 
 jobs:
   build10:

--- a/.github/workflows/Nixpkgs-GHCJS.yml
+++ b/.github/workflows/Nixpkgs-GHCJS.yml
@@ -34,5 +34,6 @@ jobs:
       uses: cachix/cachix-action@v6
       with:
         name: ${{ env.cachixAccount }}
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Determined Nix-build
       run: ./ghcjs-build.sh

--- a/.github/workflows/Nixpkgs-GHCJS.yml
+++ b/.github/workflows/Nixpkgs-GHCJS.yml
@@ -35,4 +35,4 @@ jobs:
       with:
         name: ${{ env.cachixAccount }}
     - name: Determined Nix-build
-      run: ./build.sh
+      run: ./silenced-lazy-ghcjs-build.sh

--- a/.github/workflows/Nixpkgs-GHCJS.yml
+++ b/.github/workflows/Nixpkgs-GHCJS.yml
@@ -35,4 +35,4 @@ jobs:
       with:
         name: ${{ env.cachixAccount }}
     - name: Determined Nix-build
-      run: ./silenced-lazy-ghcjs-build.sh
+      run: ./ghcjs-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ script:
   # so `SILENT` mode for it was created
   # and travis_wait 50 to wait on no outputs (otherwise Travis terminates build in 10 minutes as stale)
   # and `bash` wrapper so Travis parses `travis_wait` => `if; then; fi` line
-  - travis_wait 50 bash -c 'if [ "$compiler" = "ghcjs" ]; then ./build.sh; fi'
+  - travis_wait 50 bash -c 'if [ "$compiler" = "ghcjs" ]; then ./silenced-lazy-ghcjs-build.sh; fi'
   # NOTE: For GHCJS dump the last $ghcjsLogTailLength lines into CI out to see
   # Since build runs inside `travis_wait` - it was impossible to output log from it
   - if [ "$compiler" = "ghcjs" ]; then tail -n "$ghcjsLogTailLength" "$ghcjsTmpLogFile" && rm "$ghcjsTmpLogFile"; fi

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# NOTE: Script for the CI builds, relies on `default.nix` interface, which exposes Nixpkgs Haskell Lib interface
+# NOTE: Script to easy import nix-build settings from env, useful for tooling env replication and the CI builds, relies on `default.nix` interface, which exposes Nixpkgs Haskell Lib interface
 
 # The most strict error checking requirements
 set -Eexuo pipefail

--- a/build.sh
+++ b/build.sh
@@ -20,9 +20,11 @@ packageRoot=${packageRoot:-'pkgs.nix-gitignore.gitignoreSource [ ] ./.'}
 cabalName=${cabalName:-'replace'}
 useRev=${useRev:-'false'}
 rev=${rev:-'nixpkgs-unstable'}
+
 # Account in Cachix to use
 cachixAccount=${cachixAccount:-'replaceWithProjectNameInCachix'}
-
+# If key not provided (branch is not inside the central repo) - init CACHIX_SIGNING_KEY as empty
+CACHIX_SIGNING_KEY=${CACHIX_SIGNING_KEY:-""}
 
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 doJailbreak=${doJailbreak:-'false'}
@@ -66,9 +68,6 @@ withHoogle=${withHoogle:-'false'}
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.log'}
 # Length of the GHCJS log tail (<40000)
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
-
-# If key not provided (branch is not inside the central repo) - init CACHIX_SIGNING_KEY as empty
-CACHIX_SIGNING_KEY=${CACHIX_SIGNING_KEY:-""}
 
 
 GHCJS_BUILD(){

--- a/ghcjs-build.sh
+++ b/ghcjs-build.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# NOTE: Script to easy import nix-build settings from env, useful for tooling env replication and the CI builds, relies on `default.nix` interface, which exposes Nixpkgs Haskell Lib interface
+
+# The most strict error checking requirements
+set -Eexuo pipefail
+
+compiler=${compiler:-'default'}
+
+packageRoot=${packageRoot:-'pkgs.nix-gitignore.gitignoreSource [ ] ./.'}
+cabalName=${cabalName:-'replace'}
+useRev=${useRev:-'false'}
+rev=${rev:-'nixpkgs-unstable'}
+
+cachixAccount=${cachixAccount:-'replaceWithProjectNameInCachix'}
+CACHIX_SIGNING_KEY=${CACHIX_SIGNING_KEY:-""}
+
+allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
+doJailbreak=${doJailbreak:-'false'}
+doCheck=${doCheck:-'true'}
+
+sdistTarball=${sdistTarball:-'false'}
+buildFromSdist=${buildFromSdist:-'false'}
+
+failOnAllWarnings=${failOnAllWarnings:-'false'}
+buildStrictly=${buildStrictly:-'false'}
+
+enableDeadCodeElimination=${enableDeadCodeElimination:-'false'}
+disableOptimization=${disableOptimization:-'true'}
+linkWithGold=${linkWithGold:-'false'}
+
+enableLibraryProfiling=${enableLibraryProfiling:-'false'}
+enableExecutableProfiling=${enableExecutableProfiling:-'false'}
+doTracing=${doTracing:-'false'}
+enableDWARFDebugging=${enableDWARFDebugging:-'false'}
+doStrip=${doStrip:-'false'}
+
+enableSharedLibraries=${enableSharedLibraries:-'true'}
+enableStaticLibraries=${enableStaticLibraries:-'false'}
+enableSharedExecutables=${enableSharedExecutables:-'false'}
+justStaticExecutables=${justStaticExecutables:-'false'}
+enableSeparateBinOutput=${enableSeparateBinOutput:-'false'}
+
+checkUnusedPackages=${checkUnusedPackages:-'false'}
+doHaddock=${doHaddock:-'false'}
+doHyperlinkSource=${doHyperlinkSource:-'false'}
+doCoverage=${doCoverage:-'false'}
+doBenchmark=${doBenchmark:-'false'}
+generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:-'false'}
+executableNamesToShellComplete=${executableNamesToShellComplete:-'[ "replaceWithExecutableName" ]'}
+
+
+withHoogle=${withHoogle:-'false'}
+
+# Log file to dump GHCJS build into
+ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.log'}
+# Length of the GHCJS log tail (<40000)
+ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
+
+
+
+BUILD_PROJECT(){
+
+
+IFS=$'\n\t'
+
+if [ "$compiler" = "ghcjs" ]
+  then
+
+    # GHCJS build
+    # By itself, GHCJS creates >65000 lines of log that are >4MB in size, so Travis terminates due to log size quota.
+    # nixbuild --quiet (x5) does not work on GHC JS build
+    # So there was a need to make it build.
+    # The solution is to silence the stdout
+    # But Travis then terminates on 10 min no stdout timeout
+    # so HACK: SILENT wrapper allows to surpress the huge log, while still preserves the Cachix caching ability in any case of the build
+    # On build failure outputs the last 10000 lines of log (that should be more then enough), and terminates
+    nix-build \
+      --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
+      --arg doJailbreak "$doJailbreak" \
+      --arg doCheck "$doCheck" \
+      --arg sdistTarball "$sdistTarball" \
+      --arg buildFromSdist "$buildFromSdist" \
+      --arg failOnAllWarnings "$failOnAllWarnings" \
+      --arg buildStrictly "$buildStrictly" \
+      --arg enableDeadCodeElimination "$enableDeadCodeElimination" \
+      --arg disableOptimization "$disableOptimization" \
+      --arg linkWithGold "$linkWithGold" \
+      --arg enableLibraryProfiling "$enableLibraryProfiling" \
+      --arg enableExecutableProfiling "$enableExecutableProfiling" \
+      --arg doTracing "$doTracing" \
+      --arg enableDWARFDebugging "$enableDWARFDebugging" \
+      --arg doStrip "$doStrip" \
+      --arg doHyperlinkSource "$doHyperlinkSource" \
+      --arg enableSharedLibraries "$enableSharedLibraries" \
+      --arg enableStaticLibraries "$enableStaticLibraries" \
+      --arg enableSharedExecutables "$enableSharedExecutables" \
+      --arg justStaticExecutables "$justStaticExecutables" \
+      --arg checkUnusedPackages "$checkUnusedPackages" \
+      --arg doCoverage "$doCoverage" \
+      --arg doHaddock "$doHaddock" \
+      --arg doBenchmark "$doBenchmark" \
+      --arg generateOptparseApplicativeCompletions "$generateOptparseApplicativeCompletions" \
+      --arg executableNamesToShellComplete "$executableNamesToShellComplete" \
+      --arg withHoogle "$withHoogle" \
+      "$compiler"
+
+fi
+}
+
+MAIN() {
+
+
+# Overall it is useful to have in CI test builds the latest stable Nix
+(nix-channel --update && nix-env -u) || (sudo nix upgrade-nix) || true
+
+
+# Report the Nixpkgs channel revision
+nix-instantiate --eval -E 'with import <nixpkgs> {}; lib.version or lib.nixpkgsVersion'
+
+
+# Secrets are not shared to PRs from forks
+# nix-build | cachix push <account> - uploads binaries, runs&works only in the branches of the main repository, so for PRs - else case runs
+
+  if [ ! "$CACHIX_SIGNING_KEY" = "" ]
+
+    then
+
+      # Build of the inside repo branch - enable push Cachix cache
+      BUILD_PROJECT | cachix push "$cachixAccount"
+
+    else
+
+      # Build of the side repo/PR - can not push Cachix cache
+      BUILD_PROJECT
+
+  fi
+
+}
+
+# Run the entry function of the script
+MAIN
+

--- a/ghcjs-build.sh
+++ b/ghcjs-build.sh
@@ -5,7 +5,7 @@
 # The most strict error checking requirements
 set -Eexuo pipefail
 
-compiler=${compiler:-'default'}
+compiler=${compiler:-'ghcjs'}
 
 packageRoot=${packageRoot:-'pkgs.nix-gitignore.gitignoreSource [ ] ./.'}
 cabalName=${cabalName:-'replace'}

--- a/ghcjs/default.nix
+++ b/ghcjs/default.nix
@@ -2,77 +2,18 @@
 
 let rp = builtins.fetchTarball "https://github.com/reflex-frp/reflex-platform/archive/${rpRef}.tar.gz";
 
-    hnix-store-src = pkgs: pkgs.fetchFromGitHub {
-      owner = "haskell-nix";
-      repo = "hnix-store";
-      rev = "0.1.0.0";
-      sha256 = "1z48msfkiys432rkd00fgimjgspp98dci11kgg3v8ddf4mk1s8g0";
-    };
-
-    overlay = pkgs: with pkgs.haskell.lib; self: super:
-      let guardGhcjs = p: if self.ghc.isGhcjs or false then null else p;
-       in {
-         hashing = super.hashing;
-         haskeline = guardGhcjs super.haskeline;
-         serialise = doJailbreak super.serialise;
-
-         Glob = guardGhcjs super.Glob;
-         criterion = guardGhcjs super.criterion;
-         pretty-show = guardGhcjs super.pretty;
-         repline = guardGhcjs super.repline;
-         tasty = guardGhcjs super.tasty;
-         tasty-hunit = guardGhcjs super.tasty;
-         tasty-th = guardGhcjs super.tasty;
-         unix = guardGhcjs super.unix;
-
-         interpolate = self.callCabal2nix "interpolate" (pkgs.fetchFromGitHub {
-           owner = "sol";
-           repo = "interpolate";
-           rev = "2d654444365805458e0310d461b3ecd2826977ff";
-           sha256 = "01g88j6qv33r6j4yl6yisr9sk3kcvgp81z6qmhr94ka8z45raii9";
-         }) {};
-         lens-family-th = self.callCabal2nix "lens-family-th" (pkgs.fetchFromGitHub {
-           owner = "DanBurton";
-           repo = "lens-family-th";
-           rev = "483be4d5b53cc6253e3926623c3aa9334c53debc";
-           sha256 = "099dp4f1wwarvhwgnm4nhymnnwlqgrsgrfd8ch6dwmy6myzv2dij";
-         }) {};
-         megaparsec = dontCheck (self.callCabal2nix "megaparsec" (pkgs.fetchFromGitHub {
-           owner = "mrkkrp";
-           repo = "megaparsec";
-           rev = "7b271a5edc1af59fa435a705349310cfdeaaa7e9";
-           sha256 = "0415z18gl8dgms57rxzp870dpz7rcqvy008wrw5r22xw8qq0s13c";
-         }) {});
-         parser-combinators = self.callCabal2nix "parser-combinators" (pkgs.fetchFromGitHub {
-           owner = "mrkkrp";
-           repo = "parser-combinators";
-           rev = "dd6599224fe7eb224477ef8e9269602fb6b79fe0";
-           sha256 = "11cpfzlb6vl0r5i7vbhp147cfxds248fm5xq8pwxk92d1f5g9pxm";
-         }) {};
-         # Should be callHackage, but it gives an error "found zero or more than one cabal file"
-         # unordered-containers = pkgs.haskellPackages.callHackage "unordered-containers" "0.2.9.0" {};
-         unordered-containers = self.callCabal2nix "unordered-containers" (pkgs.fetchFromGitHub {
-           owner = "tibbe";
-           repo = "unordered-containers";
-           rev = "0a6b84ec103e28b73458f385ef846a7e2d3ea42f";
-           sha256 = "128q8k4py2wr1v0gmyvqvzikk6sksl9aqj0lxzf46763lis8x9my";
-         }) {};
-       };
 in
   (import rp {}).project ({ pkgs, ... }:
   {
-    name = "hnix-ghcjs";
+    name = "replaceWithPackageName";
     overrides = pkgs.lib.foldr pkgs.lib.composeExtensions (_: _: {})
                 [
-                 (import "${hnix-store-src pkgs}/overlay.nix")
-                 (overlay pkgs)
                 ];
     packages = {
       hnix = ../.;
     };
     
     shells = {
-      # ghc = [ "hnix" ];
       ghcjs = [ "hnix" ];
     };
   

--- a/ghcjs/default.nix
+++ b/ghcjs/default.nix
@@ -1,0 +1,79 @@
+{ rpRef ? "ea3c9a1536a987916502701fb6d319a880fdec96" }:
+
+let rp = builtins.fetchTarball "https://github.com/reflex-frp/reflex-platform/archive/${rpRef}.tar.gz";
+
+    hnix-store-src = pkgs: pkgs.fetchFromGitHub {
+      owner = "haskell-nix";
+      repo = "hnix-store";
+      rev = "0.1.0.0";
+      sha256 = "1z48msfkiys432rkd00fgimjgspp98dci11kgg3v8ddf4mk1s8g0";
+    };
+
+    overlay = pkgs: with pkgs.haskell.lib; self: super:
+      let guardGhcjs = p: if self.ghc.isGhcjs or false then null else p;
+       in {
+         hashing = super.hashing;
+         haskeline = guardGhcjs super.haskeline;
+         serialise = doJailbreak super.serialise;
+
+         Glob = guardGhcjs super.Glob;
+         criterion = guardGhcjs super.criterion;
+         pretty-show = guardGhcjs super.pretty;
+         repline = guardGhcjs super.repline;
+         tasty = guardGhcjs super.tasty;
+         tasty-hunit = guardGhcjs super.tasty;
+         tasty-th = guardGhcjs super.tasty;
+         unix = guardGhcjs super.unix;
+
+         interpolate = self.callCabal2nix "interpolate" (pkgs.fetchFromGitHub {
+           owner = "sol";
+           repo = "interpolate";
+           rev = "2d654444365805458e0310d461b3ecd2826977ff";
+           sha256 = "01g88j6qv33r6j4yl6yisr9sk3kcvgp81z6qmhr94ka8z45raii9";
+         }) {};
+         lens-family-th = self.callCabal2nix "lens-family-th" (pkgs.fetchFromGitHub {
+           owner = "DanBurton";
+           repo = "lens-family-th";
+           rev = "483be4d5b53cc6253e3926623c3aa9334c53debc";
+           sha256 = "099dp4f1wwarvhwgnm4nhymnnwlqgrsgrfd8ch6dwmy6myzv2dij";
+         }) {};
+         megaparsec = dontCheck (self.callCabal2nix "megaparsec" (pkgs.fetchFromGitHub {
+           owner = "mrkkrp";
+           repo = "megaparsec";
+           rev = "7b271a5edc1af59fa435a705349310cfdeaaa7e9";
+           sha256 = "0415z18gl8dgms57rxzp870dpz7rcqvy008wrw5r22xw8qq0s13c";
+         }) {});
+         parser-combinators = self.callCabal2nix "parser-combinators" (pkgs.fetchFromGitHub {
+           owner = "mrkkrp";
+           repo = "parser-combinators";
+           rev = "dd6599224fe7eb224477ef8e9269602fb6b79fe0";
+           sha256 = "11cpfzlb6vl0r5i7vbhp147cfxds248fm5xq8pwxk92d1f5g9pxm";
+         }) {};
+         # Should be callHackage, but it gives an error "found zero or more than one cabal file"
+         # unordered-containers = pkgs.haskellPackages.callHackage "unordered-containers" "0.2.9.0" {};
+         unordered-containers = self.callCabal2nix "unordered-containers" (pkgs.fetchFromGitHub {
+           owner = "tibbe";
+           repo = "unordered-containers";
+           rev = "0a6b84ec103e28b73458f385ef846a7e2d3ea42f";
+           sha256 = "128q8k4py2wr1v0gmyvqvzikk6sksl9aqj0lxzf46763lis8x9my";
+         }) {};
+       };
+in
+  (import rp {}).project ({ pkgs, ... }:
+  {
+    name = "hnix-ghcjs";
+    overrides = pkgs.lib.foldr pkgs.lib.composeExtensions (_: _: {})
+                [
+                 (import "${hnix-store-src pkgs}/overlay.nix")
+                 (overlay pkgs)
+                ];
+    packages = {
+      hnix = ../.;
+    };
+    
+    shells = {
+      # ghc = [ "hnix" ];
+      ghcjs = [ "hnix" ];
+    };
+  
+  })

--- a/silenced-lazy-ghcjs-build.sh
+++ b/silenced-lazy-ghcjs-build.sh
@@ -5,7 +5,7 @@
 # The most strict error checking requirements
 set -Eexuo pipefail
 
-compiler=${compiler:-'default'}
+compiler=${compiler:-'ghcjs'}
 
 packageRoot=${packageRoot:-'pkgs.nix-gitignore.gitignoreSource [ ] ./.'}
 cabalName=${cabalName:-'replace'}

--- a/silenced-lazy-ghcjs-build.sh
+++ b/silenced-lazy-ghcjs-build.sh
@@ -5,15 +5,6 @@
 # The most strict error checking requirements
 set -Eexuo pipefail
 
-### NOTE: Section handles imports from env, these are settings for Nixpkgs.
-### They use the `default.nix` interface, which exposes expose most of the Nixpkgs Haskell.lib API: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
-### Some of these options implicitly switch the dependent options.
-### Documentation of this settings is mosly in `default.nix`, since most settings it Nixpkgs related
-### Additional documentation is in Nixpkgs Haskell.lib: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
-
-
-# NOTE: If vars not imported - init the vars with default values
-# Non-set/passed ''/'default' compiler setting means currently default GHC of Nixpkgs ecosystem.
 compiler=${compiler:-'default'}
 
 packageRoot=${packageRoot:-'pkgs.nix-gitignore.gitignoreSource [ ] ./.'}
@@ -21,9 +12,7 @@ cabalName=${cabalName:-'replace'}
 useRev=${useRev:-'false'}
 rev=${rev:-'nixpkgs-unstable'}
 
-# Account in Cachix to use
 cachixAccount=${cachixAccount:-'replaceWithProjectNameInCachix'}
-# If key not provided (branch is not inside the central repo) - init CACHIX_SIGNING_KEY as empty
 CACHIX_SIGNING_KEY=${CACHIX_SIGNING_KEY:-""}
 
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
@@ -58,27 +47,66 @@ doHyperlinkSource=${doHyperlinkSource:-'false'}
 doCoverage=${doCoverage:-'false'}
 doBenchmark=${doBenchmark:-'false'}
 generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:-'false'}
-# [ "binary1" "binary2" ] - should pass " quotes into Nix interpreter
 executableNamesToShellComplete=${executableNamesToShellComplete:-'[ "replaceWithExecutableName" ]'}
 
 
 withHoogle=${withHoogle:-'false'}
 
+# Log file to dump GHCJS build into
+ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.log'}
+# Length of the GHCJS log tail (<40000)
+ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
+
+
+GHCJS_BUILD(){
+# NOTE: Function for GHCJS build that outputs its huge log into a file
+
+  # Run the build into Log (log is too long for Travis)
+  "$@" &> "$ghcjsTmpLogFile"
+
+}
+
+SILENT(){
+# NOTE: Function that silences the build process
+# In normal mode outputs only the /nix/store paths
+
+  echo "Log: $ghcjsTmpLogFile"
+  # Pass into the ghcjsbuild function the build command
+  if GHCJS_BUILD "$@"
+  then
+
+    # Output log lines for stdout -> cachix caching
+    grep '^/nix/store/' "$ghcjsTmpLogFile"
+
+  else
+
+    # Output log lines for stdout -> cachix caching
+    grep '^/nix/store/' "$ghcjsTmpLogFile"
+
+    # Propagate the error state, fail the CI build
+    exit 1
+
+  fi
+
+}
 
 BUILD_PROJECT(){
 
 
 IFS=$'\n\t'
 
-if [ ! "$compiler" = "ghcjs" ]
-   then
+if [ "$compiler" = "ghcjs" ]
+  then
 
-    # Normal GHC build
-    # GHC sometimes produces logs so big - that Travis terminates builds, so multiple --quiet
-    # If $compiler provided - use the setting - otherwise - default.
-    nix-build \
-      --quiet --quiet \
-      --argstr compiler "$compiler" \
+    # GHCJS build
+    # By itself, GHCJS creates >65000 lines of log that are >4MB in size, so Travis terminates due to log size quota.
+    # nixbuild --quiet (x5) does not work on GHC JS build
+    # So there was a need to make it build.
+    # The solution is to silence the stdout
+    # But Travis then terminates on 10 min no stdout timeout
+    # so HACK: SILENT wrapper allows to surpress the huge log, while still preserves the Cachix caching ability in any case of the build
+    # On build failure outputs the last 10000 lines of log (that should be more then enough), and terminates
+    SILENT nix-build \
       --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
       --arg doJailbreak "$doJailbreak" \
       --arg doCheck "$doCheck" \
@@ -105,7 +133,8 @@ if [ ! "$compiler" = "ghcjs" ]
       --arg doBenchmark "$doBenchmark" \
       --arg generateOptparseApplicativeCompletions "$generateOptparseApplicativeCompletions" \
       --arg executableNamesToShellComplete "$executableNamesToShellComplete" \
-      --arg withHoogle "$withHoogle"
+      --arg withHoogle "$withHoogle" \
+      "$compiler"
 
 fi
 }
@@ -114,8 +143,6 @@ MAIN() {
 
 
 # Overall it is useful to have in CI test builds the latest stable Nix
-# 2020-06-24: HACK: Do not ask why different commands on Linux and macOS. IDK, wished they we the same. These are the only commands that worked on according platforms right after the fresh Nix installer rollout.
-# 2020-07-06: HACK: GitHub Actions CI shown that nix-channel or nix-upgrade-nix do not work, there is probably some new rollout, shortcircuting for the time bing with || true
 (nix-channel --update && nix-env -u) || (sudo nix upgrade-nix) || true
 
 


### PR DESCRIPTION
Silent GHCJS build hacks were constructed to get in Travis logging limits, since that is a special case - cleaning main `build.sh` by abstracting away this special case.

PR grew into having somewhat more changes to provide somewhat more proper GHCJS build.