### PR TITLE
{default.nix,CI}: provide `rev` default for <nixpkgs>, rm `useRev`

### DIFF
--- a/.github/workflows/Nixpkgs-GHCJS.yml
+++ b/.github/workflows/Nixpkgs-GHCJS.yml
@@ -10,14 +10,13 @@ on:
     - cron: "45 05 * * *"
 
 env:
-  useRev: "true"
   rev: "nixos-unstable"
   cachixAccount: "haskell-with-nixpkgs"
   linkWithGold: "true"
 
 jobs:
   build10:
-    name: Build
+    name: "NixOS-unstable build"
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/Nixpkgs-Linux-additional.yml
+++ b/.github/workflows/Nixpkgs-Linux-additional.yml
@@ -21,7 +21,6 @@ env:
   ### and the other part of keys explained in `build.sh`, since those address external procedures aound the builds.
   ### Additional documentation is in Nixpkgs Haskell.lib: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
   ###
-  useRev: "true"
   rev: "nixos-unstable"
   cachixAccount: "haskell-with-nixpkgs"
   linkWithGold: "true"

--- a/.github/workflows/Nixpkgs-Linux-main.yml
+++ b/.github/workflows/Nixpkgs-Linux-main.yml
@@ -18,11 +18,12 @@ env:
   ### NOTE: Table example of the provided build configuration keys
   ### Infrastructure uses `build.sh` API, which uses `default.nix` API, which exposes the almost literal Nixpkgs Haskell Lib API wich was abstracted for use outside of Nix language.
   ###
-  ### Documentation of this settings is mosly in `default.nix`, since most settings it Nixpkgs related
+  ### Documentation of this settings is mosly in `default.nix`, since most settings is Nixpkgs related
   ### and the other part of keys explained in `build.sh`, since those address external procedures aound the builds.
   ### Additional documentation is in Nixpkgs Haskell.lib: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
   ###
-  useRev: "true"
+  # nixos-unstable is a nixpkgs-upstable that passed a number of upstream CI and quality checks, it is essentially a current branch while also receives stable updates fitting for our CI checkups with current Nixpkgs.
+  # Note that Nix nature is purely functional lazy language, it is referentially transparent, reproducible (deterministic) builds, that means that just as in the type system - any the Nix build failures properly cascade through the Nixpkgs tree graph branch, so particular `master` broken checkouts would properly refuse/would not be able to build parts of Nixpkgs tree graph. So the Nix builds are pretty brittle, do not be ashamed to make Nixpkgs builds optional (`continue-on-error: true`), or set them to the latest stable NixOS Nixpkgs release.
   rev: "nixos-unstable"
   # Register and use Cachix account
   cachixAccount: "haskell-with-nixpkgs"
@@ -72,11 +73,6 @@ jobs:
         name: ${{ env.cachixAccount }}
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Determined Nix-build
-      env:
-        # nixos-unstable is a nixpkgs-upstable that passed a number of upstream CI and quality checks, it is essentially a current branch while also receives stable updates fitting for our CI checkups with current Nixpkgs.
-        # Note that Nix nature is purely functional lazy language, it is referentially transparent, reproducible (deterministic) builds, that means that just as in the type system - any the Nix build failures properly cascade through the Nixpkgs tree graph branch, so particular `master` broken checkouts would properly refuse/would not be able to build parts of Nixpkgs tree graph. So the Nix builds are pretty brittle, do not be ashamed to make Nixpkgs builds optional (`continue-on-error: true`), or set them to the latest stable NixOS Nixpkgs release.
-        useRev: "true"
-        rev: "nixos-unstable"
       run: ./build.sh
 
 
@@ -100,8 +96,6 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Determined Nix-build
       env:
-        useRev: "true"
-        rev: "nixos-unstable"
         compiler: "ghc8101"
         buildFromSdist: "true"
         linkWithGold: "true"

--- a/.github/workflows/Nixpkgs-macOS.yml
+++ b/.github/workflows/Nixpkgs-macOS.yml
@@ -13,15 +13,13 @@ on:
 
 
 env:
-  useRev: "true"
   rev: "nixos-unstable"
   cachixAccount: "haskell-with-nixpkgs"
-  # GitHub secret
 
 
 jobs:
   build10:
-    name: NixOS-unstable, default GHC (8.8)
+    name: "NixOS-unstable, default GHC (8.8)"
     runs-on: macos-latest
     continue-on-error: true
     steps:

--- a/default.nix
+++ b/default.nix
@@ -80,7 +80,6 @@
 , withHoogle  ? true
 
 
-, useRev ? false
 # Nix by default updates and uses locally configured nixpkgs-unstable channel
 # Nixpkgs revision options:
 #   `rev` vals in order of freshness -> cache & stability:
@@ -92,16 +91,16 @@
 #   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
 #   ...
 #   }
-, rev ? "nixpkgs-unstable"
+, rev ? "default"
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0
     then abort "Requires Nix >= 2.0"
     else
-      if useRev
+      if ((rev == "") || (rev == "default") || (rev == "local"))
+        then import <nixpkgs> {}
         # Do not guard with hash, so the project is able to use current channels (rolling `rev`) of Nixpkgs
-        then import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz") {}
-        else import <nixpkgs> {}
+        else import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz") {}
       // {
         # Try to build dependencies even if they are marked broken.
         config.allowBroken = true;


### PR DESCRIPTION

M  .github/workflows/Nixpkgs-GHCJS.yml
M  .github/workflows/Nixpkgs-Linux-additional.yml
M  .github/workflows/Nixpkgs-Linux-main.yml
M  .github/workflows/Nixpkgs-macOS.yml
M  default.nix